### PR TITLE
impl slot trait

### DIFF
--- a/packages/runtime/example/nested-components/index.html
+++ b/packages/runtime/example/nested-components/index.html
@@ -26,6 +26,66 @@
               },
               traits: [],
             },
+            {
+              id: "btn",
+              type: "chakra_ui/v1/button",
+              properties: {
+                text: {
+                  raw: "in tab1",
+                  format: "plain",
+                },
+              },
+              traits: [
+                {
+                  type: "core/v1/slot",
+                  properties: {
+                    container: {
+                      id: "tabs",
+                      slot: "tab_content_0",
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              id: "text",
+              type: "core/v1/text",
+              properties: {
+                value: {
+                  raw: "in tab2",
+                  format: "plain",
+                },
+              },
+              traits: [
+                {
+                  type: "core/v1/slot",
+                  properties: {
+                    container: {
+                      id: "tabs",
+                      slot: "tab_content_1",
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              id: "nested_tabs",
+              type: "chakra_ui/v1/tabs",
+              properties: {
+                tabNames: ["Tab Three", "Tab Four"],
+              },
+              traits: [
+                {
+                  type: "core/v1/slot",
+                  properties: {
+                    container: {
+                      id: "tabs",
+                      slot: "tab_content_1",
+                    },
+                  },
+                },
+              ],
+            },
           ],
         },
       });

--- a/packages/runtime/src/components/_internal/Slot.tsx
+++ b/packages/runtime/src/components/_internal/Slot.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { SlotsMap } from "../../App";
+
+const Slot: React.FC<{ slotsMap: SlotsMap | undefined; slot: string }> = ({
+  slotsMap,
+  slot,
+}) => {
+  return (
+    <>
+      {(slotsMap?.get(slot) || []).map((ImplWrapper, idx) => (
+        <ImplWrapper key={idx} />
+      ))}
+    </>
+  );
+};
+
+export default Slot;

--- a/packages/runtime/src/components/chakra-ui/Button.tsx
+++ b/packages/runtime/src/components/chakra-ui/Button.tsx
@@ -11,7 +11,14 @@ const Button: ComponentImplementation<{
   colorScheme?: Static<typeof ColorSchemePropertySchema>;
   isLoading?: Static<typeof IsLoadingPropertySchema>;
   onClick?: () => void;
-}> = ({ text, mergeState, subscribeMethods, onClick, ...rest }) => {
+}> = ({
+  text,
+  mergeState,
+  subscribeMethods,
+  onClick,
+  colorScheme,
+  isLoading,
+}) => {
   const raw = useExpression(text.raw);
   useEffect(() => {
     mergeState({ value: raw });
@@ -28,7 +35,7 @@ const Button: ComponentImplementation<{
 
   return (
     <ChakraProvider>
-      <BaseButton {...rest} ref={ref} onClick={onClick}>
+      <BaseButton {...{ colorScheme, isLoading }} ref={ref} onClick={onClick}>
         <Text value={{ ...text, raw }} />
       </BaseButton>
     </ChakraProvider>

--- a/packages/runtime/src/components/chakra-ui/Tabs.tsx
+++ b/packages/runtime/src/components/chakra-ui/Tabs.tsx
@@ -8,15 +8,16 @@ import {
   TabPanel,
   ChakraProvider,
 } from "@chakra-ui/react";
-import { ComponentImplementation } from "../../registry";
 import { Type, Static } from "@sinclair/typebox";
+import { ComponentImplementation } from "../../registry";
+import Slot from "../_internal/Slot";
 
 const Tabs: ComponentImplementation<{
   tabNames: Static<typeof TabNamesPropertySchema>;
   initialSelectedTabIndex?: Static<
     typeof InitialSelectedTabIndexPropertySchema
   >;
-}> = ({ tabNames, mergeState, initialSelectedTabIndex }) => {
+}> = ({ tabNames, mergeState, initialSelectedTabIndex, slotsMap }) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState(
     initialSelectedTabIndex ?? 0
   );
@@ -37,9 +38,9 @@ const Tabs: ComponentImplementation<{
           ))}
         </TabList>
         <TabPanels>
-          {tabNames.map((name, idx) => (
+          {tabNames.map((_, idx) => (
             <TabPanel key={idx}>
-              <p>{name}</p>
+              <Slot slotsMap={slotsMap} slot={`tab_content_${idx}`} />
             </TabPanel>
           ))}
         </TabPanels>

--- a/packages/runtime/src/registry.tsx
+++ b/packages/runtime/src/registry.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { RuntimeComponent, RuntimeTrait } from "@meta-ui/core";
 import { setStore } from "./store";
+import { SlotsMap } from "./App";
 // components
 import PlainButton from "./components/plain/Button";
 import CoreText from "./components/core/Text";
@@ -9,6 +10,7 @@ import ChakraUITabs from "./components/chakra-ui/Tabs";
 // traits
 import CoreState from "./traits/core/state";
 import CoreEvent from "./traits/core/event";
+import CoreSlot from "./traits/core/slot";
 
 type ImplementedRuntimeComponent = RuntimeComponent & {
   impl: ComponentImplementation;
@@ -29,6 +31,7 @@ export type ComponentImplementation<T = any> = React.FC<
   T & {
     mergeState: MergeState;
     subscribeMethods: SubscribeMethods;
+    slotsMap: SlotsMap | undefined;
   }
 >;
 
@@ -93,3 +96,4 @@ registry.registerComponent(ChakraUITabs);
 
 registry.registerTrait(CoreState);
 registry.registerTrait(CoreEvent);
+registry.registerTrait(CoreSlot);

--- a/packages/runtime/src/store.ts
+++ b/packages/runtime/src/store.ts
@@ -7,9 +7,41 @@ export const useStore = create<Record<string, any>>(() => ({}));
 
 export const setStore = useStore.setState;
 
+export function parseExpression(raw: string): {
+  dynamic: boolean;
+  expression: string;
+} {
+  if (!raw) {
+    return {
+      dynamic: false,
+      expression: raw,
+    };
+  }
+  const matchArr = raw.match(/{{(.+)}}/);
+  if (!matchArr) {
+    return {
+      dynamic: false,
+      expression: raw,
+    };
+  }
+  return {
+    dynamic: true,
+    expression: matchArr[1],
+  };
+}
+
 // TODO: use web worker
-export function evalInContext(expression: string, ctx: Record<string, any>) {
+export function evalInContext(raw: string, ctx: Record<string, any>) {
   try {
+    const { dynamic, expression } = parseExpression(raw);
+    if (!dynamic) {
+      try {
+        // covert primitive types
+        return eval(expression);
+      } catch (error) {
+        return expression;
+      }
+    }
     Object.keys(ctx).forEach((key) => {
       // @ts-ignore
       self[key] = ctx[key];
@@ -26,40 +58,16 @@ export function evalInContext(expression: string, ctx: Record<string, any>) {
   }
 }
 export function useExpression(raw: string) {
-  const { dynamic, expression } = useMemo(() => {
-    if (!raw) {
-      return {
-        dynamic: false,
-        expression: raw,
-      };
-    }
-    const matchArr = raw.match(/{{(.+)}}/);
-    if (!matchArr) {
-      return {
-        dynamic: false,
-        expression: raw,
-      };
-    }
-    return {
-      dynamic: true,
-      expression: matchArr[1],
-    };
-  }, [raw]);
-
   const [state, setState] = useState<any>(
-    evalInContext(expression, useStore.getState())
+    evalInContext(raw, useStore.getState())
   );
-
-  if (!dynamic) {
-    return state;
-  }
 
   useStore.subscribe(
     (value) => {
       setState(value);
     },
     (state) => {
-      return evalInContext(expression, state);
+      return evalInContext(raw, state);
     }
   );
 

--- a/packages/runtime/src/traits/core/slot.ts
+++ b/packages/runtime/src/traits/core/slot.ts
@@ -1,0 +1,28 @@
+import { createTrait } from "@meta-ui/core";
+import { Type } from "@sinclair/typebox";
+
+export const ContainerPropertySchema = Type.Object({
+  id: Type.String(),
+  slot: Type.String(),
+});
+
+export default {
+  ...createTrait({
+    version: "core/v1",
+    metadata: {
+      name: "slot",
+      description: "nested components by slots",
+    },
+    spec: {
+      properties: [
+        {
+          name: "container",
+          ...ContainerPropertySchema,
+        },
+      ],
+      state: {},
+      methods: [],
+    },
+  }),
+  impl: () => {},
+};


### PR DESCRIPTION
impl #11 

![image](https://user-images.githubusercontent.com/13651389/126960240-7c23f5a1-6ad5-4231-948b-f4ee736aeb80.png)


To implement slot trait, we do the following changes
1. Nestable components should embed <Slot /> inside itself.
2. Attachable components should use the slot trait to indicate which container they will be attached to.

During app render, we will resolve the nested relation by traversing the components spec. This process will return top-level components and a resolved slots tree.

Top-level components will be rendered directly. The resolved slots tree will be passed into every <Slot />, so the embed <Slot /> can render which has been attached to itself.