### PR TITLE
update the spec of component ids in the spec

### DIFF
--- a/packages/core/__tests__/application.spec.ts
+++ b/packages/core/__tests__/application.spec.ts
@@ -9,7 +9,6 @@ describe('application', () => {
           name: 'test-app',
           description: 'first application',
         },
-
         spec: {
           components: [
             {
@@ -72,5 +71,28 @@ describe('application', () => {
         "version": "demo/v1",
       }
     `);
+  });
+
+  it('will validate component id', () => {
+    expect(() =>
+      createApplication({
+        version: 'demo/v1',
+        metadata: {
+          name: 'test-app',
+          description: 'first application',
+        },
+
+        spec: {
+          components: [
+            {
+              id: 'input-1',
+              type: 'core/v1/test_component',
+              properties: {},
+              traits: [],
+            },
+          ],
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(`"Invalid id: \\"input-1\\""`);
   });
 });

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -67,6 +67,10 @@ function parseType(v: string): VersionAndName {
   };
 }
 
+function isValidId(id: string): boolean {
+  return /^[a-zA-Z_$][0-9a-zA-Z_$]+$/.test(id);
+}
+
 export function createApplication(
   options: Omit<Application, 'kind'>
 ): RuntimeApplication {
@@ -77,6 +81,9 @@ export function createApplication(
     spec: {
       ...options.spec,
       components: options.spec.components.map(c => {
+        if (!isValidId(c.id)) {
+          throw new Error(`Invalid id: "${c.id}"`);
+        }
         return {
           ...c,
           parsedType: parseType(c.type),

--- a/spec/zh_CN/SPEC.md
+++ b/spec/zh_CN/SPEC.md
@@ -63,7 +63,6 @@ Component 的模型定义了自身对外提供的配置项与可接受的 trait�
 | --------- | ------ | -------- | ------------- | ----------- |
 | name      | String | Y        |               | Trait 名称  |
 
-
 ### MethodSchema
 
 | Attribute  | Type       | Required | Default Value | Description |
@@ -255,15 +254,16 @@ Application 由平台使用者定义，描述了哪些 Component、Trait、Scope
 | Attribute  | Type                   | Required | Default Value | Description                     |
 | ---------- | ---------------------- | -------- | ------------- | ------------------------------- |
 | components | ApplicationComponent[] | Y        |               | Application 中的 Component 配置 |
+
 ### ApplicationComponent
 
-| Attribute  | Type                                | Required | Default Value | Description                                      |
-| ---------- | ----------------------------------- | -------- | ------------- | ------------------------------------------------ |
-| id         | String                              | Y        |               | Component 在应用中的唯一标识                     |
-| type       | String                              | Y        |               | 对应 Component `metadata` 中的 `name`            |
-| properties | JSON                                | Y        |               | 对应 Component `spec` 中 `properties` 定义的模型 |
-| traits     | [ComponentTrait](#ComponentTrait)[] | Y        |               | Component 使用的 Trait 定义                      |
-| scopes     |                                     | N        |               | TO_BE_DETERMINED                                 |
+| Attribute  | Type                                | Required | Default Value | Description                                                           |
+| ---------- | ----------------------------------- | -------- | ------------- | --------------------------------------------------------------------- |
+| id         | String                              | Y        |               | Component 在应用中的唯一标识，需满足正则：/[a-zA-Z\_$][0-9a-za-z_$]+/ |
+| type       | String                              | Y        |               | 对应 Component `metadata` 中的 `name`                                 |
+| properties | JSON                                | Y        |               | 对应 Component `spec` 中 `properties` 定义的模型                      |
+| traits     | [ComponentTrait](#ComponentTrait)[] | Y        |               | Component 使用的 Trait 定义                                           |
+| scopes     |                                     | N        |               | TO_BE_DETERMINED                                                      |
 
 ### ComponentTrait
 
@@ -326,4 +326,3 @@ Application 由平台使用者定义，描述了哪些 Component、Trait、Scope
   }
 }
 ```
-


### PR DESCRIPTION
related to #54
If users naming component with id 'input-1', it may be hard to be
used in the expression, because 'input-1' is not a valid JS variable
name.

So we update the spec to make sure component ids are valid JS variable
names.
According to https://stackoverflow.com/a/1661249, a valid JS variable
name can be a big set. In this patch, we just force users to pass
a simple and limited RegExp, which keeps the application simple and readable.

TODO: validate component ids are not keywords.